### PR TITLE
Add educa2.madrid.org

### DIFF
--- a/lib/domains/org/madrid
+++ b/lib/domains/org/madrid
@@ -1,0 +1,1 @@
+Digital Platform used by all K-12 and Higher Education Centers on Madrid (No names, it's a collection of schools using the same platform)


### PR DESCRIPTION
The domain used by hundrends of K-12 schools and higher education schools on Madrid.

#### Institution/School Name 
Educa Madrid Platform (All Highschools, Higher Education Centers & K-12 Education)

#### Instiution/School Website
https://www.educa2.madrid.org/educamadrid/


#### Email Users

*Please place an x between the square brackets if yes*
- [ X ] Students
- [ X ] Academic/Teaching Staff
- [ ] Other/Support Staff
- [ ] Alumni

#### Education Levels

*Please place an x between the square brackets if yes*

- [ ] Post-graduate research
- [ ] Graduate School
- [ X ] College (University) or Undergraduate School or equivalent
- [ X ] Community College or equivalent
- [ X ] High School or equivalent
- [ X ] Elementary School or equivalent
